### PR TITLE
write closed_loop int into input.c file

### DIFF
--- a/src/dsverifier.cpp
+++ b/src/dsverifier.cpp
@@ -1859,6 +1859,7 @@ void state_space_parser()
   verification_file.append(";\n double error_limit = ");
   cf_value_precision  << std::fixed << desired_quantization_limit;
   verification_file.append(cf_value_precision.str());
+  verification_file.append(";\n int closed_loop = "+std::string(closedloop ? "1": "0"));
   verification_file.append(";\n void initials(){\n");
 
   for (i=0; i<_controller.nStates; i++)


### PR DESCRIPTION
Fix to set extern int closed_loop to 1 if —closed-loop is used an input
command and 0 otherwise. 

Previously closed_loop is never written to. This means that int verify_error_state_space(void) will never run the code for closed_loop

